### PR TITLE
db: add album_user to allow multiple users

### DIFF
--- a/app/controllers/panel/albums_controller.rb
+++ b/app/controllers/panel/albums_controller.rb
@@ -3,16 +3,20 @@
 module Panel
   class AlbumsController < ApplicationController
     before_action :authenticate_user!
-    before_action :set_album, only: %i[show update destroy]
+    before_action :set_album, only: %i[check_owner show update destroy]
+    before_action :check_authorized_user, only: %i[show]
+    before_action :check_owner, only: %i[update destroy]
 
     # GET /albums or /albums.json
     def index
-      @albums = Album.all
       results = []
+      albums = set_albums
 
-      @albums.each do |album|
-        result = album_result(album)
-        results.push(result)
+      unless albums.empty?
+        albums.each do |album|
+          result = album_result(album)
+          results.push(result)
+        end
       end
 
       render json: results
@@ -20,23 +24,29 @@ module Panel
 
     # GET /albums/1 or /albums/1.json
     def show
+      return redirect_to panel_path if @album.nil?
+
       render json: album_result(@album)
     end
 
     # POST /albums or /albums.json
     def create
-      @album = Album.new(album_params)
-      @album.user = current_user
+      album = Album.new(album_params)
+      album.user = current_user
 
-      if @album.save
-        render json: @album, status: :created
+      if album.save
+        AlbumUser.create(user: current_user, album:)
+        render json: album, status: :created
       else
-        render json: @album.errors, status: :unprocessable_entity
+        render json: album.errors, status: :unprocessable_entity
       end
     end
 
     # PATCH/PUT /albums/1 or /albums/1.json
     def update
+      # only the owner can update the album
+      return redirect_to panel_path if @album.user != current_user
+
       if @album.update(album_params)
         render json: @album
         # redirect_to album_url(@album), notice: "Album was successfully updated."
@@ -48,7 +58,9 @@ module Panel
 
     # DELETE /albums/1 or /albums/1.json
     def destroy
-      # @album.destroy
+      # only the owner can delete the album
+      return redirect_to panel_path if @album.user != current_user
+
       if @album.destroy
         render json: { message: 'Album was successfully destroyed.' }
       else
@@ -58,7 +70,18 @@ module Panel
 
     private
 
-    # Use callbacks to share common setup or constraints between actions.
+    def check_authorized_user
+      album_user = AlbumUser.find_by(album_id: params[:id], user_id: current_user.id)
+
+      redirect_to panel_path if album_user.nil? && return
+    end
+
+    def check_owner
+      return unless @album.user != current_user
+
+      render(json: { error: 'Unauthorized' }, status: :unauthorized) && return
+    end
+
     def album_result(album)
       album_cover = ''
       album_cover = album.photos.first.image unless album.photos.first.nil?
@@ -69,6 +92,14 @@ module Panel
 
     def set_album
       @album = Album.find(params[:id])
+    end
+
+    def set_albums
+      # all albums that are shared with the current user (owner included)
+      @albums = Album
+                .left_outer_joins(:album_users)
+                .where(album_users: { user_id: current_user.id })
+                .distinct
     end
 
     # Only allow a list of trusted parameters through.

--- a/app/javascript/apis/panel.api.ts
+++ b/app/javascript/apis/panel.api.ts
@@ -1,5 +1,4 @@
 import type { AxiosResponse } from 'axios';
-import axios from 'axios';
 import { http } from '@/services/http.service';
 
 // Album
@@ -87,20 +86,15 @@ export const getUploadProgressApi = (
 
 // Review
 export const updateReviewApi = (
+  album_id: number,
   photo_id: number,
   review_id: number | null,
   angle: number,
 ): Promise<AxiosResponse> => {
-  return axios.put(`http://localhost:3000/panel/photos/${photo_id}/photo_user_reviews`, {
+  return http.put(`${album_id}/photos/${photo_id}/photo_user_reviews`, {
     review_id,
     angle,
+    controller: 'photo_user_reviews',
+    action: 'update',
   });
-  // return http.put(`photos/${photo_id}/photo_user_reviews`, {
-  //   //   'photo_user_review': { review_value, angle },
-  //   // });
-  //   review_value,
-  //   angle,
-  //   controller: 'photo_user_reviews',
-  //   action: 'update',
-  // });
 };

--- a/app/javascript/components/panel/Photo.vue
+++ b/app/javascript/components/panel/Photo.vue
@@ -75,7 +75,6 @@ import { ref, computed, type PropType, watch } from 'vue';
 import { Cloudinary } from '@cloudinary/url-gen';
 import { byAngle } from '@cloudinary/url-gen/actions/rotate';
 import { AdvancedImage } from '@cloudinary/vue';
-import type { AxiosResponse } from 'axios';
 import { updateReviewApi } from '@/apis/panel.api';
 
 const emit = defineEmits(['reviewed-photo', 'close-review-photo', 'navigate-photo']);
@@ -166,7 +165,12 @@ function saveReview(index = 0) {
   if (!displayedPhoto) return;
 
   if (displayedPhoto?.review_results || photoOriginalAngles.value[index] !== displayedPhoto.angle) {
-    updateReviewApi(displayedPhoto.id, displayedPhoto.review_results, displayedPhoto.angle)
+    updateReviewApi(
+      displayedPhoto.album_id,
+      displayedPhoto.id,
+      displayedPhoto.review_results,
+      displayedPhoto.angle,
+    )
       .then(() => {
         rotateCounters.value[index] = 0;
         return;

--- a/app/javascript/components/panel/PhotoUpload.vue
+++ b/app/javascript/components/panel/PhotoUpload.vue
@@ -205,7 +205,7 @@ const uploadPhoto = async () => {
   }
 
   // getProgressUntilComplete();
-
+  console.log('uploading photo', props.album.id);
   createPhotoApi(props.album.id, photoUploadOption.value, inputFiles.value)
     .then((response: AxiosResponse) => {
       $emit('close-upload-photo');

--- a/app/models/album.rb
+++ b/app/models/album.rb
@@ -18,4 +18,5 @@ class Album < ApplicationRecord
   belongs_to :user
   has_many :photos, dependent: :destroy
   has_many :uploads, dependent: :destroy
+  has_many :album_users, dependent: :destroy
 end

--- a/app/models/album_user.rb
+++ b/app/models/album_user.rb
@@ -1,0 +1,19 @@
+# == Schema Information
+#
+# Table name: album_users
+#
+#  id         :bigint           not null, primary key
+#  album_id   :bigint           not null
+#  user_id    :bigint           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_album_users_on_album_id  (album_id)
+#  index_album_users_on_user_id   (user_id)
+#
+class AlbumUser < ApplicationRecord
+  belongs_to :album
+  belongs_to :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,4 +31,5 @@ class User < ApplicationRecord
 
   has_many :albums, dependent: :destroy
   has_many :photo_user_reviews, dependent: :destroy
+  has_many :album_users, dependent: :destroy
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,13 +15,13 @@ Rails.application.routes.draw do
   get '/panel', to: 'application#panel', as: :panel
   namespace :panel do
     resources :albums do
-      resources :photos, only: %i[index create]
+      resources :photos, only: %i[index create show update destroy] do
+        get '/photo_user_reviews', to: 'photo_user_reviews#index'
+        put '/photo_user_reviews', to: 'photo_user_reviews#update'
+      end
+      delete '/delete_photos', to: 'photos#destroy_multiple', as: 'delete_photos'
     end
-    resources :photos, only: %i[show update destroy] do
-      get '/photo_user_reviews', to: 'photo_user_reviews#index'
-      put '/photo_user_reviews', to: 'photo_user_reviews#update'
-    end
-    delete '/delete_photos', to: 'photos#destroy_multiple', as: 'delete_photos'
+
   end
   get '/(*path)', to: 'application#website', as: :website
 

--- a/db/migrate/20240501120222_create_album_users.rb
+++ b/db/migrate/20240501120222_create_album_users.rb
@@ -1,0 +1,10 @@
+class CreateAlbumUsers < ActiveRecord::Migration[7.0]
+  def change
+    create_table :album_users do |t|
+      t.references :album, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_04_20_172156) do
+ActiveRecord::Schema[7.0].define(version: 2024_05_01_120222) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -40,6 +40,15 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_20_172156) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "album_users", force: :cascade do |t|
+    t.bigint "album_id", null: false
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["album_id"], name: "index_album_users_on_album_id"
+    t.index ["user_id"], name: "index_album_users_on_user_id"
   end
 
   create_table "albums", force: :cascade do |t|
@@ -120,6 +129,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_20_172156) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "album_users", "albums"
+  add_foreign_key "album_users", "users"
   add_foreign_key "albums", "users"
   add_foreign_key "allowlisted_jwts", "users", on_delete: :cascade
   add_foreign_key "photo_user_reviews", "photos"

--- a/spec/models/album_user_spec.rb
+++ b/spec/models/album_user_spec.rb
@@ -1,0 +1,20 @@
+# == Schema Information
+#
+# Table name: album_users
+#
+#  id         :bigint           not null, primary key
+#  album_id   :bigint           not null
+#  user_id    :bigint           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_album_users_on_album_id  (album_id)
+#  index_album_users_on_user_id   (user_id)
+#
+require 'rails_helper'
+
+RSpec.describe AlbumUser, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
Logic:

Logged in user can create album.

Album owner can authorize users to their album.
Owner can edit and delete album, edit every attribute of a photo, delete photo.

Authorized user can view album, view and add photo, edit photo's angle, add and edit photo review, see all reviews.