### PR TITLE
fix: show page instead of json object when refresh

### DIFF
--- a/app/controllers/panel/albums_controller.rb
+++ b/app/controllers/panel/albums_controller.rb
@@ -27,7 +27,7 @@ module Panel
       return redirect_to panel_path if @album.nil?
 
       respond_to do |format|
-        format.html { render template: 'layouts/panel'} # or whatever to simply render html
+        format.html { render template: 'layouts/panel'}
         format.json { render json: album_result(@album) }
       end
     end

--- a/app/javascript/apis/panel.api.ts
+++ b/app/javascript/apis/panel.api.ts
@@ -17,7 +17,7 @@ export const createAlbumApi = (album: album): Promise<AxiosResponse> => {
 };
 
 export const showAlbumApi = (id: number): Promise<AxiosResponse> => {
-  return http.get(`${id}`); // not 'albums/${id}' because of Rails' default behavior params_wrapper.
+  return http.get(`${id}.json`); // not 'albums/${id}' because of Rails' default behavior params_wrapper.
 };
 
 export const updateAlbumApi = (id: number, album: album): Promise<AxiosResponse> => {
@@ -50,7 +50,8 @@ export const createPhotoApi = (
       headers: {
         'Content-Type': 'multipart/form-data',
       },
-  });
+    },
+  );
 };
 
 export const showPhotoApi = (albumId: number, id: number): Promise<AxiosResponse> => {


### PR DESCRIPTION
- Issue: on first load or when navigating to other pages, eerything works. When refreshing, the page shows a json object. 71cd26c78870e658ff0a04ce169f2db51baed820 fixed and showed the html, without the json.
- Fix: specify .json in the http call.