### PR TITLE
feat: edit invitee, input email

### DIFF
--- a/app/controllers/panel/albums_controller.rb
+++ b/app/controllers/panel/albums_controller.rb
@@ -14,8 +14,7 @@ module Panel
 
       unless albums.empty?
         albums.each do |album|
-          result = album_result(album)
-          results.push(result)
+          results.push(album.attach_cover)
         end
       end
 
@@ -27,8 +26,8 @@ module Panel
       return redirect_to panel_path if @album.nil?
 
       respond_to do |format|
-        format.html { render template: 'layouts/panel'} # or whatever to simply render html
-        format.json { render json: album_result(@album) }
+        format.html { render template: 'layouts/panel'}
+        format.json { render json: @album.attach_cover }
       end
     end
 
@@ -36,15 +35,11 @@ module Panel
     def create
       album = Album.new(album_params)
       album.user = current_user
+      invitees = sanitize_invitees_email unless params[:invitees].nil?
 
       if album.save
         AlbumUser.create(user: current_user, album:)
-        # if invitees are current users, create an Album_User record and send an email to them
-        params[:invitees].split(',').each do |invitee|
-          UserNotifierMailer.send_album_invitation_email(album, invitee).deliver
-          user = User.find_by(email: invitee)
-          AlbumUser.create(user: user, album: album) unless user.nil?
-        end
+        album.share(invitees, true) unless invitees.nil?
         render json: album, status: :created
       else
         render json: album.errors, status: :unprocessable_entity
@@ -56,12 +51,13 @@ module Panel
       # only the owner can update the album
       return redirect_to panel_path if @album.user != current_user
 
+      invitees = sanitize_invitees_email unless params[:invitees].nil?
+
       if @album.update(album_params)
         render json: @album
-        # redirect_to album_url(@album), notice: "Album was successfully updated."
+        @album.share(invitees, false) unless invitees.nil?
       else
         render json: @album.errors, status: :unprocessable_entity
-        # render :edit, status: :unprocessable_entity
       end
     end
 
@@ -91,12 +87,12 @@ module Panel
       render(json: { error: 'Unauthorized' }, status: :unauthorized) && return
     end
 
-    def album_result(album)
-      album_cover = ''
-      album_cover = album.photos.first.image unless album.photos.first.nil?
-      album_result = {}.merge(album.attributes)
-      album_result[:cover] = album_cover
-      album_result
+    def sanitize_invitees_email
+      result = []
+      params[:invitees].each do |invitee|
+        result.push(invitee) if invitee != '' && invitee.match(URI::MailTo::EMAIL_REGEXP)
+      end
+      result
     end
 
     def set_album
@@ -113,7 +109,8 @@ module Panel
 
     # Only allow a list of trusted parameters through.
     def album_params
-      params.require(:album).permit(:name, :expiry_date, :last_update_batch)
+      # params.require(:album).permit(:name, :expiry_date, :last_update_batch, :invitees => []) # rubocop:disable Style/HashSyntax
+      params.require(:album).permit(:name, :expiry_date, :last_update_batch, invitees: [])
     end
   end
 end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -10,10 +10,10 @@ class RegistrationsController < Devise::RegistrationsController
   end
 
   def register_success(resource)
-    p 'register_success'
-    p resource
-    p resource.email
     UserNotifierMailer.send_signup_email(resource).deliver
+    # TODO
+    # check if the user email is shared in the invitees list of any album?
+    # registration email should have the link with the album shared with the user
     render jsonapi: resource
   end
 

--- a/app/javascript/apis/panel.api.ts
+++ b/app/javascript/apis/panel.api.ts
@@ -5,7 +5,7 @@ import { http } from '@/services/http.service';
 interface album {
   name: string;
   expiry_date: Date;
-  invitees: string;
+  invitees: string[];
 }
 
 export const getAlbumsApi = (): Promise<AxiosResponse> => {
@@ -17,7 +17,8 @@ export const createAlbumApi = (album: album): Promise<AxiosResponse> => {
 };
 
 export const showAlbumApi = (id: number): Promise<AxiosResponse> => {
-  return http.get(`${id}`); // not 'albums/${id}' because of Rails' default behavior params_wrapper.
+  return http.get(`${id}.json`);
+  // not 'albums/${id}' because of Rails' default behavior params_wrapper.
 };
 
 export const updateAlbumApi = (id: number, album: album): Promise<AxiosResponse> => {
@@ -50,7 +51,8 @@ export const createPhotoApi = (
       headers: {
         'Content-Type': 'multipart/form-data',
       },
-  });
+    },
+  );
 };
 
 export const showPhotoApi = (albumId: number, id: number): Promise<AxiosResponse> => {

--- a/app/javascript/components/panel/AlbumCreate.vue
+++ b/app/javascript/components/panel/AlbumCreate.vue
@@ -4,6 +4,7 @@
       <input
         v-model="albumName"
         type="text"
+        required
         placeholder="Album name"
         class="w-full px-2 py-1 text-xl text-black rounded"
       />
@@ -18,8 +19,9 @@
       <label for="invitee" class="self-center text-lg">Invitee</label>
       <input
         v-model="invitees"
-        type="text"
-        required
+        type="email"
+        multiple
+        pattern="^([\w+-.%]+@[\w-.]+\.[A-Za-z]{2,4},*[\W]*)+$"
         placeholder=" reviewer@gmail.com,..."
         class="w-3/4 pl-1 rounded text-lg text-black"
       />
@@ -70,8 +72,7 @@ const $emit = defineEmits(['close-create-album', 'added-new-album']);
 
 const albumName = ref('');
 const albumExpiryDate = ref(new Date());
-const invitees = ref('');
-// invitees: invitees.value,
+const invitees = ref([]);
 const createAlbum = async () => {
   createAlbumApi({
     name: albumName.value,
@@ -90,7 +91,7 @@ const createAlbum = async () => {
 const closeCreateAlbum = () => {
   albumName.value = '';
   albumExpiryDate.value = new Date();
-  invitees.value = '';
+  invitees.value = [];
   $emit('close-create-album');
 };
 </script>

--- a/app/javascript/components/panel/AlbumEdit.vue
+++ b/app/javascript/components/panel/AlbumEdit.vue
@@ -1,0 +1,140 @@
+<template>
+  <div class="relative px-6 pt-16 pb-8 bg-white dark:bg-slate-800 border rounded">
+    <div class="flex place-content-between w-full mb-6">
+      <input
+        v-model="name"
+        type="text"
+        required
+        placeholder="Album name"
+        class="w-full px-2 py-1 text-xl text-black rounded"
+      />
+    </div>
+
+    <div class="flex place-content-between mb-4">
+      <label for="expiry-date" class="self-center text-lg">Expiry date</label>
+      <input v-model="expiryDate" type="date" class="pl-1 rounded text-lg text-black" />
+    </div>
+
+    <div class="flex place-content-between mb-4">
+      <label for="invitee" class="text-lg">Invitee</label>
+      <div class="tag-input ml-2.5">
+        <!-- pattern="^([\w+-.%]+@[\w-.]+\.[A-Za-z]{2,4},*[\W]*)+$" -->
+        <input
+          v-model="newInvitee"
+          type="email"
+          class="w-full py-1 px-2 text-lg text-black rounded"
+          @keydown.enter="addInvitee"
+          @keydown.prevent.tab="addInvitee"
+          @keydown.delete="newInvitee.length || removeInvitee(0)"
+        />
+        <ul class="tags">
+          <li v-for="invitee in invitees" :key="invitee" class="tag">
+            {{ invitee }}
+            <font-awesome-icon
+              icon="fa-solid fa-x"
+              class="ml-2 cursor-pointer"
+              @click="removeInvitee(invitees.indexOf(invitee))"
+            />
+          </li>
+        </ul>
+      </div>
+    </div>
+
+    <div class="w-full">
+      <button
+        class="w-full mt-4 py-3 bg-violet-600 text-slate-200 rounded text-xl font-bold cursor-pointer"
+        @click="saveEditAlbum"
+      >
+        Save
+      </button>
+    </div>
+
+    <font-awesome-icon
+      icon="fa-solid fa-x"
+      class="absolute top-4 right-4 text-slate-400"
+      @click="closeEditAlbum()"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+import type { AxiosResponse } from 'axios';
+import { updateAlbumApi } from '@/apis/panel.api';
+
+const $emit = defineEmits(['close-edit-album', 'edited-album']);
+
+const props = defineProps({
+  albumId: {
+    type: Number,
+    required: true,
+  },
+  albumName: {
+    type: String,
+    required: true,
+  },
+  albumExpiryDate: {
+    type: Date,
+    required: true,
+  },
+  albumInvitees: {
+    type: Array<string>,
+    required: true,
+  },
+});
+
+const name = ref(props.albumName);
+const expiryDate = ref(props.albumExpiryDate);
+const invitees = ref(props.albumInvitees);
+const newInvitee = ref('');
+
+const addInvitee = () => {
+  if (newInvitee.value) {
+    invitees.value.unshift(newInvitee.value);
+    newInvitee.value = '';
+  }
+};
+
+const removeInvitee = (index: number) => {
+  invitees.value.splice(index, 1);
+};
+
+const saveEditAlbum = async () => {
+  updateAlbumApi(props.albumId, {
+    name: name.value,
+    expiry_date: expiryDate.value,
+    invitees: invitees.value,
+  })
+    .then((response: AxiosResponse) => {
+      $emit('edited-album', response.data);
+    })
+    .catch((error) => {
+      console.log(error);
+    });
+};
+
+const closeEditAlbum = () => {
+  $emit('close-edit-album');
+};
+</script>
+
+<style scoped>
+.tag-input {
+  width: 100%;
+}
+ul.tags {
+  list-style: none;
+  width: 100%;
+  overflow-x: auto;
+}
+.tag {
+  width: fit-content;
+  margin-top: 8px;
+  padding: 0 8px 2px 4px;
+  border-radius: 4px;
+  background: var(--color-primary);
+  color: white;
+  white-space: nowrap;
+  transition: 0.1s ease background;
+}
+</style>

--- a/app/javascript/pages/panel/AlbumsPage.vue
+++ b/app/javascript/pages/panel/AlbumsPage.vue
@@ -59,7 +59,7 @@ interface Album {
   id: number;
   name: string;
   expiry_date: Date;
-  invitees: string;
+  invitees: string[];
   cover: string;
   last_upload_batch: number;
 }

--- a/app/mailers/user_notifier_mailer.rb
+++ b/app/mailers/user_notifier_mailer.rb
@@ -1,13 +1,13 @@
 class UserNotifierMailer < ApplicationMailer
-  default :from => 'any_from_address@example.com'
+  default from: 'tuoanhnt951@gmail.com'
 
   # send a signup email to the user, pass in the user object that contains the user's email address
   def send_signup_email(user)
     @user = user
     @user_name = @user.email.split('@').first
     @signin_url = user_session_url
-    mail( :to => @user.email,
-    :subject => 'Thanks for signing up for our amazing app' )
+    mail(to: @user.email,
+         subject: 'Thanks for signing up for our amazing app') # rubocop:disable Rails/I18nLocaleTexts
   end
 
   # send an email to invitees to with a link of the album
@@ -17,7 +17,7 @@ class UserNotifierMailer < ApplicationMailer
     # @user = user
     @user_name = user_email.split('@').first
     @album_owner_email = @album.user.email
-    mail( :to => user_email,
-    :subject => 'You have been invited to an album.' )
+    mail(to: user_email,
+         subject: 'You have been invited to an album.')
   end
 end

--- a/app/models/album.rb
+++ b/app/models/album.rb
@@ -9,6 +9,7 @@
 #  user_id           :bigint           not null
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
+#  invitees          :text             default([]), is an Array
 #
 # Indexes
 #
@@ -19,4 +20,49 @@ class Album < ApplicationRecord
   has_many :photos, dependent: :destroy
   has_many :uploads, dependent: :destroy
   has_many :album_users, dependent: :destroy
+
+  def cover
+    return '' if photos.empty?
+
+    photos.first&.image
+  end
+
+  def attach_cover
+    album_result = {}.merge(attributes)
+    album_result[:cover] = cover
+    p '----------------------'
+    p 'attach_cover'
+    p cover
+    p album_result
+    p '----------------------'
+    album_result
+  end
+
+  def share(emails, is_new)
+    p '----------------------'
+    p 'start share'
+    p emails
+    # TODO: remove users that are not in the invitees list from the album users
+    emails.each do |email|
+      p '----------------------'
+      p 'loop email'
+      p email
+      UserNotifierMailer.send_album_invitation_email(self, email).deliver
+      user = User.find_by(email:)
+      p 'user'
+      p user
+      next unless user
+      p '----------------------'
+      p 'user exists. Is Album new?'
+      p is_new
+      p 'Is the album shared with the user?'
+      p shared_with?(user)
+      p !is_new && shared_with?(user)
+      album_users.create(user_id: user.id) unless !is_new && shared_with?(user)
+    end
+  end
+
+  def shared_with?(user)
+    album_users.exists?(user_id: user.id)
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   mount Sidekiq::Web => '/sidekiq'
   root to: 'application#website'
-
+  # get '/(*path)', to: 'application#panel', constraints: ->(request) { request.format == :html }
   devise_for :users, defaults: { format: :json }, skip: :all
   devise_scope :user do
     # If you change these urls and helpers, you must change these files too:
@@ -21,9 +21,6 @@ Rails.application.routes.draw do
       delete '/delete_photos', to: 'photos#destroy_multiple', as: 'delete_photos'
       get '/photo_user_reviews', to: 'photo_user_reviews#index'
     end
-
   end
   get '/(*path)', to: 'application#website', as: :website
-
-
 end

--- a/db/migrate/20240511145226_add_invitees_to_albums.rb
+++ b/db/migrate/20240511145226_add_invitees_to_albums.rb
@@ -1,0 +1,5 @@
+class AddInviteesToAlbums < ActiveRecord::Migration[7.0]
+  def change
+    add_column :albums, :invitees, :text, array: true, default: []
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_05_01_120222) do
+ActiveRecord::Schema[7.0].define(version: 2024_05_11_145226) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -58,6 +58,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_01_120222) do
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "invitees", default: [], array: true
     t.index ["user_id"], name: "index_albums_on_user_id"
   end
 

--- a/spec/models/album_invitee_spec.rb
+++ b/spec/models/album_invitee_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe AlbumInvitee, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/album_spec.rb
+++ b/spec/models/album_spec.rb
@@ -9,6 +9,7 @@
 #  user_id           :bigint           not null
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
+#  invitees          :text             default([]), is an Array
 #
 # Indexes
 #

--- a/spec/requests/albums_spec.rb
+++ b/spec/requests/albums_spec.rb
@@ -9,6 +9,7 @@
 #  user_id           :bigint           not null
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
+#  invitees          :text             default([]), is an Array
 #
 # Indexes
 #


### PR DESCRIPTION
![Screen Shot 2024-05-14 at 21 44 25](https://github.com/tuoanhnt95/Photo-review-6/assets/102507273/1ff36e76-5a21-459b-ba16-7a3218e0cb1d)

When album owner opens context Menu and selects Edit, s/he can add or remove invitees.

- Added field 'invitees' of array of string to Album.
- Check that email is legit, is a registered user, and has been linked to Album