### PR TITLE
fix: split file name with multiple .

### DIFF
--- a/app/services/image_processor.rb
+++ b/app/services/image_processor.rb
@@ -84,11 +84,16 @@ class ImageProcessor < ApplicationService
 
   # replace extension with '.jpg
   def image_name(file_name)
+    return file_name if image_is_jpg(file_name)
+
+    # if image has multiple '.' in the name, split by the last '.'
+    return "#{file_name.split('.')[0..-2].join('.')}.jpg" if file_name.split('.').length > 2
+
     "#{file_name.split('.')[0]}.jpg"
   end
 
   def image_extension(file_name)
-    file_name.split('.')[1].downcase
+    file_name.split('.')[-1].downcase
   end
 
   def image_is_jpg(file_name)


### PR DESCRIPTION
- Issue: when processing image, some images get corrupted. Terminal outputs error of missing file with the file name being incomplete.
- Cause: image name and extension gets split by the first ".". When an image's name has multiple ".", the splitting was wrong, causing image process failure. 
Ex: One ".": "Sony 78.ARW" -> "SONY 78" and "ARW" => Correct
      Multiple ".": "Sony 78.2024.05.ARW" -> "SONY 78" and "2024" => Incorrect
- Fix: split the name by the last "."

![image](https://github.com/tuoanhnt95/Photo-review-6/assets/102507273/64f8a165-3aaa-444b-9b78-f381815b74e0)
