### PR TITLE
feat: change upload from multiple to single file

### DIFF
--- a/app/controllers/panel/uploads_controller.rb
+++ b/app/controllers/panel/uploads_controller.rb
@@ -4,87 +4,80 @@ require 'open-uri'
 require './lib/modules/file_input'
 
 # Uploads controller
-class UploadsController < ApplicationController
-  include FileInput
-  before_action :set_upload, only: %i[show update destroy]
-  before_action :set_album, only: %i[create show_progress]
-  # skip_before_action :verify_authenticity_token
-  # skip_before_action :authenticate_user!
+module Panel
+  class UploadsController < ApplicationController
+    include FileInput
+    before_action :set_album, only: %i[find_upload_by_name]
+    before_action :set_upload, only: %i[show update destroy]
 
-  # GET /uploads
-  def index
-    @uploads = Upload.all
+    # GET /uploads
+    def index
+      @uploads = Upload.all
 
-    render json: @uploads
-  end
-
-  # GET /uploads/1
-  def show
-    render json: @upload
-  end
-
-  # POST /uploads
-  def create
-    @upload = Upload.new(upload_params)
-
-    if @upload.save
-      render json: @upload, status: :created, location: @upload
-    else
-      render json: @upload.errors, status: :unprocessable_entity
+      render json: @uploads
     end
-  end
 
-  # PATCH/PUT /uploads/1
-  def update
-    if @upload.update(upload_params)
+    # GET /uploads/1
+    def show
       render json: @upload
-    else
-      render json: @upload.errors, status: :unprocessable_entity
     end
-  end
 
-  # DELETE /uploads/1
-  def destroy
-    @upload.destroy
-  end
+    # POST /uploads
+    def create
+      upload = Upload.new(upload_params)
 
-  def show_progress
-    results = []
-    file_names = JSON.parse(params[:file_names])
-    file_types = JSON.parse(params[:file_types])
-    file_names.each_with_index do |file_name, i|
+      if upload.save
+        render json: upload, status: :created, location: upload
+      else
+        render json: upload.errors, status: :unprocessable_entity
+      end
+    end
 
-      file_names.each_with_index do |file_name, i|
-        return render(json: { error: 'Invalid file type.' }, status: :unprocessable_entity) unless check_file_type_whitelist!(file_name, file_types[i])
+    # PATCH/PUT /uploads/1
+    def update
+      if @upload.update(upload_params)
+        render json: @upload
+      else
+        render json: @upload.errors, status: :unprocessable_entity
+      end
+    end
+
+    # DELETE /uploads/1
+    def destroy
+      @upload.destroy
+    end
+
+    def show_progress
+      unless check_file_type_whitelist!(params[:file_name], params[:file_type])
+        return render(json: { error: 'Invalid file type.' }, status: :unprocessable_entity)
       end
 
+      render json: find_upload_by_name
+    end
+
+    private
+
+    # For last upload batch, increment in frontend and send it to backend, not increment per upload
+    def find_upload_by_name
       upload = Upload.find_by(
         album_id: params[:album_id],
-        name: file_name,
-        batch: @album.last_upload_batch
+        name: params[:file_name]
       )
 
-      if upload
-        results.push({ name: upload.name, progress: upload.progress }) if upload
-      else
-        results.push({ name: file_name, progress: 0 })
-      end
+      { name: params[:file_name], progress: upload ? upload.progress : 0 }
     end
-    render json: results
-  end
 
-  private
+    def set_album
+      @album = Album.find(params[:album_id])
+    end
 
-  def set_album
-    @album = Album.find(params[:album_id])
-  end
+    def set_upload
+      @upload = Upload.find(params[:id])
+    end
 
-  def set_upload
-    @upload = Upload.find(params[:id])
-  end
-
-  # Only allow a list of trusted parameters through.
-  def upload_params
-    params.require(:upload).permit(:name, :progress, :album_id, :file_names, :file_types, :batch)
+    # Only allow a list of trusted parameters through.
+    def upload_params
+      params.require(:upload).permit(:name, :progress, :album_id, :file_name, :file_type, :batch)
+    end
   end
 end

--- a/app/javascript/apis/panel.api.ts
+++ b/app/javascript/apis/panel.api.ts
@@ -2,7 +2,7 @@ import type { AxiosResponse } from 'axios';
 import { http } from '@/services/http.service';
 
 // Album
-interface album {
+interface Album {
   name: string;
   expiry_date: Date;
   invitees: string[];
@@ -12,7 +12,7 @@ export const getAlbumsApi = (): Promise<AxiosResponse> => {
   return http.get('/panel/albums');
 };
 
-export const createAlbumApi = (album: album): Promise<AxiosResponse> => {
+export const createAlbumApi = (album: Album): Promise<AxiosResponse> => {
   return http.post('/panel/albums', { album });
 };
 
@@ -20,7 +20,7 @@ export const showAlbumApi = (id: number): Promise<AxiosResponse> => {
   return http.get(`/panel/albums/${id}.json`);
 };
 
-export const updateAlbumApi = (id: number, album: album): Promise<AxiosResponse> => {
+export const updateAlbumApi = (id: number, album: Album): Promise<AxiosResponse> => {
   return http.put(`/panel/albums/${id}`, { album });
 };
 
@@ -33,7 +33,7 @@ export const deleteAlbumApi = (id: number): Promise<AxiosResponse> => {
 };
 
 // Photo
-interface photo {
+interface Photo {
   name: string;
   image: string;
 }
@@ -45,11 +45,11 @@ export const getPhotosApi = (albumId: number): Promise<AxiosResponse> => {
 export const createPhotoApi = (
   albumId: number,
   upload_option: number,
-  files: File[],
+  file: File,
 ): Promise<AxiosResponse> => {
   return http.post(
     `/panel/albums/${albumId}/photos`,
-    { upload_option, files },
+    { upload_option, file },
     {
       headers: {
         'Content-Type': 'multipart/form-data',
@@ -65,7 +65,7 @@ export const showPhotoApi = (albumId: number, id: number): Promise<AxiosResponse
 export const updatePhotoApi = (
   albumId: number,
   id: number,
-  photo: photo,
+  photo: Photo,
 ): Promise<AxiosResponse> => {
   return http.put(`/panel/albums/${albumId}/photos/${id}`, { photo });
 };
@@ -81,9 +81,11 @@ export const deletePhotosApi = (photoIds: number[]): Promise<AxiosResponse> => {
 // Upload Progress
 export const getUploadProgressApi = (
   albumId: number,
-  queryString: string,
+  fileName: string,
+  fileType: string,
 ): Promise<AxiosResponse> => {
-  return http.get(`/panel/albums/${albumId}/upload_progress${queryString}`, {
+  return http.get(`/panel/albums/${albumId}/upload_progress`, {
+    params: { file_name: fileName, file_type: fileType },
     headers: {
       'Content-Type': 'application/json',
     },

--- a/app/javascript/pages/panel/AlbumPage.vue
+++ b/app/javascript/pages/panel/AlbumPage.vue
@@ -135,7 +135,7 @@
                 />
               </td>
               <td @click.prevent="showPhoto(photo.id)">
-                <div>{{ photo.name }}</div>
+                <div class="text-wrap border border-solid border-red-500">{{ photo.name }}</div>
                 <!-- TODO: Show original size -->
                 <div class="text-xs text-slate-400"></div>
               </td>
@@ -215,7 +215,7 @@
       :action="action"
       :albumId="album.id"
       :albumName="album.name"
-      :albumExpiryDate="album.expiry_date.toISOString().split('T')[0]"
+      :albumExpiryDate="album.expiry_date.toString()"
       :albumInvitees="album.invitees"
       class="absolute top-[-200px] left-0 w-full z-10"
       @close-edit-album="action = ''"
@@ -425,11 +425,8 @@ function removePhoto(photoId: number) {
   photosData.value.splice(index, 1);
 }
 
-function addPhoto(photos: [Photo]) {
-  photos.forEach((photo) => {
-    // photosData.value.unshift(photo);
-    photosData.value.push(photo);
-  });
+function addPhoto(photo: Photo) {
+  photosData.value.unshift(photo);
 }
 
 function formatDate(date: Date) {

--- a/app/services/image_processor.rb
+++ b/app/services/image_processor.rb
@@ -12,11 +12,10 @@ class ImageProcessor < ApplicationService
   end
 
   def call
-    file_name_without_extension = @file.original_filename.split('.')[0]
     cloudinary_image = process_image
     url = cloudinary_image['secure_url']
     public_id = cloudinary_public_id(url)
-    { img_name: file_name_without_extension, img_url: public_id }
+    { img_name: get_file_name_without_extension(@file.original_filename), img_url: public_id }
   end
 
   private
@@ -86,24 +85,28 @@ class ImageProcessor < ApplicationService
   def image_name(file_name)
     return file_name if image_is_jpg(file_name)
 
-    # if image has multiple '.' in the name, split by the last '.'
-    return "#{file_name.split('.')[0..-2].join('.')}.jpg" if file_name.split('.').length > 2
-
-    "#{file_name.split('.')[0]}.jpg"
+    "#{get_file_name_without_extension(file_name)}.jpg"
   end
 
-  def image_extension(file_name)
-    file_name.split('.')[-1].downcase
+  def get_file_extension(file_name)
+    file_name.split('.').last.downcase
+  end
+
+  def get_file_name_without_extension(file_name)
+    # if image has multiple '.' in the name, split by the last '.' and join the rest
+    return file_name.split('.')[0..-2].join('.').to_s if file_name.split('.').length > 2
+
+    (file_name.split('.')[0]).to_s
   end
 
   def image_is_jpg(file_name)
-    image_extension(file_name) == 'jpg' || image_extension(file_name) == 'jpeg'
+    get_file_extension(file_name) == 'jpg' || get_file_extension(file_name) == 'jpeg'
   end
 
   def image_uses_magicload(file_name)
     magickload_formats = %w[arw cr2 crw dng heic nef nrw orf pef raf srw]
     # magickload_formats = %w[arw cr2 crw dng nef nrw orf pef raf srw rw2 x3f gpr]
-    image_extension(file_name).in? magickload_formats
+    get_file_extension(file_name).in? magickload_formats
   end
 
   def get_image_resized(option)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,6 @@
 Rails.application.routes.draw do
   mount Sidekiq::Web => '/sidekiq'
   root to: 'application#website'
-  # get '/(*path)', to: 'application#panel', constraints: ->(request) { request.format == :html }
   devise_for :users, defaults: { format: :json }, skip: :all
   devise_scope :user do
     # If you change these urls and helpers, you must change these files too:
@@ -21,6 +20,7 @@ Rails.application.routes.draw do
       put '/add_invitees', to: 'albums#add_invitees'
       delete '/delete_photos', to: 'photos#destroy_multiple', as: 'delete_photos'
       get '/photo_user_reviews', to: 'photo_user_reviews#index'
+      get '/upload_progress', to: 'uploads#show_progress'
     end
   end
   get '/(*path)', to: 'application#website', as: :website

--- a/lib/modules/file_input.rb
+++ b/lib/modules/file_input.rb
@@ -5,6 +5,13 @@ module FileInput
     file_name.split('.').last.downcase
   end
 
+  def get_file_name_without_extension(file_name)
+    # if image has multiple '.' in the name, split by the last '.' and join the rest
+    return file_name.split('.')[0..-2].join('.').to_s if file_name.split('.').length > 2
+
+    (file_name.split('.')[0]).to_s
+  end
+
   def file_extension_whitelist
     %w[arw bmp cr2 crw dng heic jpg jpeg nef nrw orf pef png raf srw tif tiff]
   end


### PR DESCRIPTION
- Files were sent to API in a batch. This made the process inflexible, more difficult if user cancel uploading one file, or showing upload progress, update photo list as soon as photo is saved. 
- Heroku server host backend has no API call limit, Cloudinary has a limit of 25000 transformation/month aka upload, delete, not per API call. Therefore, number of API call is not an issue.
- Separate to make each API call for more flexibility.