### PR TITLE
feat: show upload per photo, add duplicate check for input

### DIFF
--- a/app/javascript/pages/panel/AlbumPage.vue
+++ b/app/javascript/pages/panel/AlbumPage.vue
@@ -3,7 +3,7 @@
   <div class="w-full h-full">
     <div
       class="relative w-full"
-      :class="{ 'opacity-10 saturate-0': isUploadingPhoto || isShowingPhoto }"
+      :class="{ 'opacity-40 saturate-40': isUploadingPhoto || isShowingPhoto }"
     >
       <div class="flex justify-between mx-8 mt-4">
         <div class="label-text">
@@ -225,8 +225,9 @@
     <PhotoUpload
       v-if="isUploadingPhoto"
       :album="album"
+      :albumPhotoNames="photos.map((photo) => photo.name)"
       class="absolute top-0 left-0 w-full h-full z-10"
-      @uploaded-new-photo="(photos) => addPhoto(photos)"
+      @uploaded-new-photo="(photo) => addPhoto(photo)"
       @close-upload-photo="isUploadingPhoto = false"
     />
 


### PR DESCRIPTION
- Show photo as soon as it finishes upload, not waiting for the whole upload batch. User does not need to refresh to see newly uploaded photo.
- Add check for files that are already uploaded, or has been added in inputFiles. The second check is not required now, when every "Upload" with reset the files input. In the future, consider being able to add more files by clicking "Upload".
- Duplicate or invalid formatted photos have red text.

![image](https://github.com/tuoanhnt95/Photo-review-6/assets/102507273/c6932f6b-fc8a-4a70-ac21-24488452e567)
