### PR TITLE
fix: correct sender list

### DIFF
--- a/app/controllers/panel/albums_controller.rb
+++ b/app/controllers/panel/albums_controller.rb
@@ -51,20 +51,22 @@ module Panel
     # PATCH/PUT /albums/1 or /albums/1.json
     def update
       removed_invitees = list_removed_invitees
+      to_be_added_invitees = added_invitees
 
       if !@album.name.empty? && @album.update(create_update_album)
         @album.remove_invitees(removed_invitees) unless removed_invitees.empty?
         render json: @album
-        @album.share(added_invitees, false) unless added_invitees.empty?
+        @album.share(to_be_added_invitees, false) unless to_be_added_invitees.empty?
       else
         render json: @album.errors, status: :unprocessable_entity
       end
     end
 
     def add_invitees
+      to_be_added_invitees = added_invitees
       if @album.update(invitees: @invitees)
         render json: @album
-        @album.share(added_invitees, false)
+        @album.share(to_be_added_invitees, false)
       else
         render json: @album.errors, status: :unprocessable_entity
       end

--- a/app/mailers/user_notifier_mailer.rb
+++ b/app/mailers/user_notifier_mailer.rb
@@ -14,10 +14,9 @@ class UserNotifierMailer < ApplicationMailer
   def send_album_invitation_email(album, user_email)
     @album = album
     @album_url = panel_album_url(@album)
-    # @user = user
     @user_name = user_email.split('@').first
     @album_owner_email = @album.user.email
     mail(to: user_email,
-         subject: 'You have been invited to an album.')
+         subject: 'ShootSelect: Album invitation')
   end
 end

--- a/app/views/user_notifier_mailer/send_album_invitation_email.html.erb
+++ b/app/views/user_notifier_mailer/send_album_invitation_email.html.erb
@@ -4,11 +4,11 @@
   <title>Album Invitation</title>
 </head>
 <body>
-  <h1>Hello, <%= @user_name %>!</h1>
+  <h1>Hello, <%= @user_name.capitalize %>!</h1>
   <p>You have been invited by <%= @album_owner_email %> to review the album "<%= @album.name %>":</p>
   <a href="<%= @album_url %>">View Album</a>
   <%# <p>If you have any questions, feel free to reply to this email.</p> %>
   <p>Best,</p>
-  <p>Pickture Team</p>
+  <p>ShootSelect Team</p>
 </body>
 </html>


### PR DESCRIPTION
- Issue: when new invitee is added to album, email was not sent to the needed emails.
- Cause: backend calculated the needed emails of new invitees as what is in frontend invitee emails, but not in database invitee emails. When updating album, the database invitee list got updated to the frontend invitee list, so there is no difference, hence no new invitees. Therefore, no email was sent.
- Fix: calculate the new invitees before updating album invitees. 

![image](https://github.com/tuoanhnt95/Photo-review-6/assets/102507273/cbf9bf36-8ef5-4bd3-bd66-2362f7549156)

