### PR TITLE
fix-build: add alias to @ path due to potential vite failure

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,12 @@
 import { defineConfig } from 'vite';
 import RubyPlugin from 'vite-plugin-ruby';
 import vue from '@vitejs/plugin-vue';
+import path from 'path';
 
 export default defineConfig({
   resolve: {
     extensions: ['.mjs', '.js', '.ts', '.jsx', '.tsx', '.json', '.vue'],
+    alias: { '~@fortawesome': path.resolve(__dirname, 'node_modules/@fortawesome') },
   },
   plugins: [vue(), RubyPlugin()],
   css: {


### PR DESCRIPTION
Issue: When building for deploy Heroku, Vite failed to import fortawesome.

error during build:
remote:        Error: [vite]: Rollup failed to resolve import "@fortawesome/vue-fontawesome" from "/tmp/build_b833bab1/app/javascript/entrypoints/setupEntryPoint.ts".
remote:        This is most likely unintended because it can break your application at runtime.
remote:        If you do want to externalize this module explicitly add it to
remote:        `build.rollupOptions.external`

Cause: possibly due to  Vite not being able to find @paths.
[https://stackoverflow.com/a/76910981/19858571](url)

Solution: add alias and path to the fortawesome. Tested that app runs locally with the alias. Comment this fix to github, then try to push in heroku main.
[https://stackoverflow.com/q/72134347/19858571](url)