### PR TITLE
fix: change vite setting vue template to accept relative url

### DIFF
--- a/app/javascript/entrypoints/setupEntryPoint.ts
+++ b/app/javascript/entrypoints/setupEntryPoint.ts
@@ -2,13 +2,10 @@ import { Component, createApp } from 'vue';
 import { Router } from 'vue-router';
 import { VueQueryPlugin } from 'vue-query';
 /* import font awesome icon component */
-// import { FontAwesomeIcon } from '../../../../node_modules/@fortawesome/vue-fontawesome';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 /* import the fontawesome core */
-// import { library } from '../../../../node_modules/@fortawesome/fontawesome-svg-core';
 import { library } from '@fortawesome/fontawesome-svg-core';
 //  import fontawesome brands
-// import { faLinkedinIn } from '../../../../node_modules/@fortawesome/free-brands-svg-icons';
 import { faLinkedinIn } from '@fortawesome/free-brands-svg-icons';
 /* import specific icons */
 import {
@@ -51,9 +48,7 @@ import {
   faChevronLeft,
   faUpRightAndDownLeftFromCenter,
   faDownLeftAndUpRightToCenter,
-// } from '../../../../node_modules/@fortawesome/free-solid-svg-icons';
 } from '@fortawesome/free-solid-svg-icons';
-// import { faSquareMinus, faImages, faEnvelope } from '../../../../node_modules/@fortawesome/free-regular-svg-icons';
 import { faSquareMinus, faImages, faEnvelope } from '@fortawesome/free-regular-svg-icons';
 
 import { globalProperties } from './globalProperties';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,14 +1,21 @@
 import { defineConfig } from 'vite';
 import RubyPlugin from 'vite-plugin-ruby';
 import vue from '@vitejs/plugin-vue';
-import path from 'path';
 
 export default defineConfig({
   resolve: {
     extensions: ['.mjs', '.js', '.ts', '.jsx', '.tsx', '.json', '.vue'],
-    // alias: { '~@fortawesome': path.resolve(__dirname, '/node_modules/@fortawesome') },
   },
-  plugins: [vue(), RubyPlugin()],
+  plugins: [
+    vue({
+      template: {
+        transformAssetUrls: {
+          includeAbsolute: false,
+        },
+      },
+    })
+    , RubyPlugin()
+  ],
   css: {
     preprocessorOptions: {
       scss: {


### PR DESCRIPTION
Issue: when build for deploy, cannot resolve public folder's images in vue template using relative path
Cause: vite plugin vue does not allow relative URLs asset pointed to public folder. 
[https://github.com/vitejs/vite/issues/4836#issuecomment-914620573](url)
Solution: change setting in vite for vue to not require absolute urls
[https://qiita.com/ma7ma7pipipi/items/558f3e13945ec8e6623c](url)