### PR TITLE
build: add app version

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -8,6 +8,7 @@ require 'sidekiq/web'
 Bundler.require(*Rails.groups)
 
 module PhotoReview6
+  VERSION = '0.1.0'.freeze
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.0
@@ -39,16 +40,17 @@ module PhotoReview6
     config.action_cable.url = ENV.fetch('ACTION_CABLE_FRONTEND_URL') { 'ws://localhost:28080' }
 
     # Only allow connections to Action Cable from these domains.
-    origins = ENV.fetch('ACTION_CABLE_ALLOWED_REQUEST_ORIGINS') { "http:\/\/localhost*" }.split(',')
+    origins = ENV.fetch('ACTION_CABLE_ALLOWED_REQUEST_ORIGINS') { 'http://localhost*' }.split(',')
     origins.map! { |url| /#{url}/ }
     config.action_cable.allowed_request_origins = origins
 
     # Protect sidekiq-web
     Sidekiq::Web.use(Rack::Auth::Basic) do |username, password|
-      ActiveSupport::SecurityUtils.secure_compare(username, ENV.fetch('SIDEKIQ_WEB_USERNAME', 'sidekiq-web-dashboard')) &&
+      ActiveSupport::SecurityUtils.secure_compare(username,
+                                                  ENV.fetch('SIDEKIQ_WEB_USERNAME', 'sidekiq-web-dashboard')) &&
         ActiveSupport::SecurityUtils.secure_compare(password, ENV.fetch('SIDEKIQ_WEB_PASSWORD', 'sidekiq-web-123'))
     end
 
-    config.action_mailer.default_url_options = { host: ENV['DEFAULT_HOST'] }
+    config.action_mailer.default_url_options = { host: ENV.fetch('DEFAULT_HOST', nil) }
   end
 end


### PR DESCRIPTION
Issue: when running app in Heroku, app crashes due to zeitwerk 

    2024-08-17T08:27:51.454219+00:00 heroku[web.1]: Starting process with command `bin/rails server -p ${PORT:-5000} -e production`
    2024-08-17T08:27:54.136747+00:00 app[web.1]: => Booting Puma
    2024-08-17T08:27:54.136766+00:00 app[web.1]: => Rails 7.0.8 application starting in production
    2024-08-17T08:27:54.136766+00:00 app[web.1]: => Run `bin/rails server --help` for more startup options
    2024-08-17T08:27:54.773273+00:00 app[web.1]: Exiting
    2024-08-17T08:27:54.773714+00:00 app[web.1]: /app/vendor/bundle/ruby/3.2.0/gems/zeitwerk-2.6.12/lib/zeitwerk/loader/callbacks.rb:33:in `on_file_autoloaded': expected file /app/app/controllers/panel/reviews_controller.rb to define constant Panel::ReviewsController, but didn't (Zeitwerk::NameError)
    2024-08-17T08:27:54.773714+00:00 app[web.1]: 
    2024-08-17T08:27:54.773716+00:00 app[web.1]: raise Zeitwerk::NameError.new(msg, cref.last)

Cause: Zeitwerk autoloads constants. In the boot process, versioning the app is needed with Zeitwerk.
Solution: Version app
[https://stackoverflow.com/a/78453240/19858571](url)
